### PR TITLE
Fix issue when response contains a node with the same name as an existing class

### DIFF
--- a/lib/tripit.rb
+++ b/lib/tripit.rb
@@ -182,8 +182,8 @@ class TravelObj
         element.elements.each do |e|
             if /^[A-Z]/.match(e.name)
                 name = e.name.intern
-                klass = if TripIt.const_defined?(name)
-                    TripIt.const_get(name)
+                klass = if TripIt.const_defined?(name,false)
+                    TripIt.const_get(name,false)
                 else
                     TripIt.const_set(name, Class.new(TravelObj))
                 end


### PR DESCRIPTION
If we receive a response like 

`<Response><timestamp>1394617345</timestamp><num_bytes>6625</num_bytes><Trip>....`

and we have an existing class called `Trip`, the process could crash while trying to create the `Trip` object. The code in `TravelObj#new` tries to get and crate constants that belongs to a module, but it does it inheriting. This change just avoids inheriting, so that it looks only in the module.
